### PR TITLE
Add Docker Compose for Open WebUI and Ollama

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS
+
+This repository provides a Docker Compose stack for running Ollama together with Open WebUI.
+
+## Build and Run
+
+1. Install Python dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+2. Start the services:
+   ```sh
+   docker compose up -d
+   ```
+
+## Guidelines
+
+- Keep `README.md`, `requirements.txt`, and `docker-compose.yml` consistent.
+- Exposed ports: 11434 for Ollama and 3000 for Open WebUI.
+- Use two spaces for indentation in YAML and Markdown files.
+
+## Testing
+
+- Run `docker compose config` to validate compose files before committing.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# Ollamahome
+# Ollama Home
+
+This repository provides a Docker Compose configuration for running [Ollama](https://ollama.ai) together with [Open WebUI](https://github.com/open-webui/open-webui). The stack exposes both services on your local network so you can host an AI chat interface at home.
+
+## Requirements
+
+- Docker Desktop on Windows 11 with the WSL2 backend.
+- Python 3.8+ with `pip`.
+- Install Python dependencies:
+  ```sh
+  pip install -r requirements.txt
+  ```
+- Optional: an NVIDIA GPU with drivers and the NVIDIA Container Toolkit for hardware acceleration.
+
+## Usage
+
+1. Start the services:
+   ```sh
+   docker compose up -d
+   ```
+2. Open your browser to `http://localhost:3000` to access Open WebUI.
+   - From other devices on your network, replace `localhost` with the IP address of this PC.
+3. The Ollama API is available on port `11434` for programmatic access.
+
+### Managing models
+
+Use the Open WebUI interface or run commands inside the `ollama` container, for example:
+
+```sh
+docker exec -it ollama ollama run llama3
+```
+
+### Stopping
+
+```sh
+docker compose down
+```
+
+## Optional configuration
+
+- To persist data, volumes are created for both Ollama and Open WebUI.
+- GPU acceleration can be enabled by configuring Docker to expose your GPU (e.g. `--gpus all` or setting `NVIDIA_VISIBLE_DEVICES=all`).
+- Ports can be adjusted in `docker-compose.yml` if needed.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    depends_on:
+      - ollama
+    restart: unless-stopped
+    ports:
+      - "3000:8080"
+    environment:
+      - OLLAMA_API_BASE=http://ollama:11434
+      - WEBUI_HOST=0.0.0.0
+    volumes:
+      - open-webui:/app/backend/data
+
+volumes:
+  ollama:
+  open-webui:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+docker
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- Add Docker Compose stack running Ollama and Open WebUI with persistent volumes and network exposure for local access
- Document setup steps, model management, optional GPU configuration, and how to install prerequisites
- Provide repository guidance in AGENTS.md

## Testing
- `pip install -r requirements.txt`
- `docker compose config` *(fails: docker: 'compose' is not a docker command)*

------
https://chatgpt.com/codex/tasks/task_e_688e5e473bc48331baf61fc475ef5e72